### PR TITLE
Updated from link to repo to link to git

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You'll need [Node.js](https://nodejs.org) to build this site:
 
 ```bash
 # Clone repository
-git clone https://github.com/jord/essential-electron
+git clone https://github.com/jord/essential-electron.git
 # Go into repository clone
 cd essential-electron
 # Install dependencies


### PR DESCRIPTION
git clone requires the `.git` extension to successfully clone the repo to get started.
